### PR TITLE
add containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,16 @@
+FROM python:3
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y iperf3
+
+COPY static ./static
+COPY templates ./templates
+COPY app.py .
+
+RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \
+    pip install --requirement /tmp/requirements.txt
+
+EXPOSE 5000
+
+ENTRYPOINT python3 /app/app.py


### PR DESCRIPTION
I use `iperf3` frequently during work and this web UI is great to have handy, so I wrapped it in a container.

This could probably be improved to allow users to customize the frontend with their own css using volumes, but that doesn't seem important enough to deal with right now.

Run it with the following steps:

```bash
podman build -t iperf3-webui .
podman run -it -p 5000:5000 iperf3-webui
```

Docker should be the same.