### PR TITLE
Add requests to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 psutil
 flask
 pyyaml
+requests


### PR DESCRIPTION
Fix `ModuleNotFoundError: No module named 'requests'`